### PR TITLE
修正重启项目时可能发生的脚本单例冲突

### DIFF
--- a/plugin.gd
+++ b/plugin.gd
@@ -9,19 +9,8 @@ const SETTING_SCRIPT: Script = preload("res://addons/godot_core_system/setting.g
 const SETTING_INFO_DICT: Dictionary[StringName, Dictionary] = SETTING_SCRIPT.SETTING_INFO_DICT
 
 
-## 在项目运行前添加单例以避免脚本引用单例冲突
-func _build() -> bool:
-	add_autoload_singleton(SYSTEM_NAME, SYSTEM_PATH)
-	return true
-
-
-## 在项目运行时添加项目设置
+## 在插件运行时添加项目设置
 func _enter_tree() -> void:
-	_add_project_settings()
-
-
-## 在启用插件时进行初始化
-func _enable_plugin() -> void:
 	_add_project_settings()
 	add_autoload_singleton(SYSTEM_NAME, SYSTEM_PATH)
 	ProjectSettings.save()

--- a/plugin.gd
+++ b/plugin.gd
@@ -8,18 +8,61 @@ const SYSTEM_PATH: String = "res://addons/godot_core_system/source/core_system.g
 const SETTING_SCRIPT: Script = preload("res://addons/godot_core_system/setting.gd")
 const SETTING_INFO_DICT: Dictionary[StringName, Dictionary] = SETTING_SCRIPT.SETTING_INFO_DICT
 
-func _enter_tree():
-	# 确保项目设置分类存在
-	#_ensure_project_settings_category()
-	# 添加模块设置
+
+## 在项目运行前添加单例以避免脚本引用单例冲突
+func _build() -> bool:
+	add_autoload_singleton(SYSTEM_NAME, SYSTEM_PATH)
+	return true
+
+
+## 在项目运行时添加项目设置
+func _enter_tree() -> void:
+	_add_project_settings()
+
+
+## 在启用插件时进行初始化
+func _enable_plugin() -> void:
 	_add_project_settings()
 	add_autoload_singleton(SYSTEM_NAME, SYSTEM_PATH)
 	ProjectSettings.save()
 
-func _exit_tree():
-	ProjectSettings.save()
-	_remove_project_settings()
+
+## 在禁用插件时恢复项目配置
+func _disable_plugin() -> void:
 	remove_autoload_singleton(SYSTEM_NAME)
+	_remove_project_settings()
+	ProjectSettings.save()
+
+
+## 添加配置脚本中的设置项
+func _add_project_settings() -> void:
+	for setting_dict in SETTING_INFO_DICT.values():
+		_add_setting_dict(setting_dict)
+
+
+## 移除配置脚本中的设置项
+func _remove_project_settings() -> void:
+	for setting_dict in SETTING_INFO_DICT.values():
+		_remove_setting_dict(setting_dict)
+
+
+## 使用hint_dictionary添加选项
+func _add_setting_dict(info_dict: Dictionary) -> void:
+	var setting_name: String = info_dict["name"]
+	if not ProjectSettings.has_setting(setting_name):
+		ProjectSettings.set_setting(setting_name, info_dict["default"])
+
+	ProjectSettings.set_as_basic(setting_name, info_dict["basic"])
+	ProjectSettings.set_initial_value(setting_name, info_dict["default"])
+	ProjectSettings.add_property_info(info_dict)
+
+
+## 使用hint_dictionary移除选项
+func _remove_setting_dict(info_dict: Dictionary) -> void:
+	var setting_name: String = info_dict["name"]
+	if ProjectSettings.has_setting(setting_name):
+		ProjectSettings.set_setting(setting_name, null)
+
 
 ## 添加单个设置项
 func _add_setting(name: String, default_value, type: int, hint: int, hint_string: String = "") -> void:
@@ -34,6 +77,7 @@ func _add_setting(name: String, default_value, type: int, hint: int, hint_string
 		"hint_string": hint_string
 	})
 
+
 ## 确保项目设置中有我们的分类
 func _ensure_project_settings_category() -> void:
 	if not ProjectSettings.has_setting("godot_core_system/modules"):
@@ -45,29 +89,3 @@ func _ensure_project_settings_category() -> void:
 			"hint": PROPERTY_HINT_NONE,
 			"hint_string": "Core System Modules"
 		})
-
-## 添加配置脚本中的设置项
-func _add_project_settings() -> void:
-	for setting_dict in SETTING_INFO_DICT.values():
-		_add_setting_dict(setting_dict)
-
-## 移除配置脚本中的设置项
-func _remove_project_settings() -> void:
-	for setting_dict in SETTING_INFO_DICT.values():
-		_remove_setting_dict(setting_dict)
-
-## 使用hint_dictionary添加选项
-func _add_setting_dict(info_dict: Dictionary) -> void:
-	var setting_name: String = info_dict["name"]
-	if not ProjectSettings.has_setting(setting_name):
-		ProjectSettings.set_setting(setting_name, info_dict["default"])
-
-	ProjectSettings.set_as_basic(setting_name, info_dict["basic"])
-	ProjectSettings.set_initial_value(setting_name, info_dict["default"])
-	ProjectSettings.add_property_info(info_dict)
-
-## 使用hint_dictionary移除选项
-func _remove_setting_dict(info_dict: Dictionary) -> void:
-	var setting_name: String = info_dict["name"]
-	if ProjectSettings.has_setting(setting_name):
-		ProjectSettings.set_setting(setting_name, null)


### PR DESCRIPTION
原因为原本每次_exit_tree()调用时都会移除单例，但单例不应当移除而是保存状态至下次打开。
用_disable_plugin()可以完美代替其原有的功能。