### PR TITLE
修复订阅，取消订阅时非匿名回调函数无法正常判断的错误 #22

### DIFF
--- a/source/event_system/event_bus.gd
+++ b/source/event_system/event_bus.gd
@@ -95,7 +95,7 @@ func subscribe(
 	
 	# 检查是否已存在相同的回调
 	for sub in _subscriptions[event_name]:
-		if sub.callback == callback:
+		if (sub.is_anonymous and sub.callback == callback) or (not sub.is_anonymous and sub.callback_method == callback.get_method()):
 			if debug_mode:
 				print("[EventBus] Callback already subscribed to event: %s" % event_name)
 			else:
@@ -117,9 +117,14 @@ func unsubscribe(event_name: String, callback: Callable) -> void:
 	
 	var index = -1
 	for i in range(_subscriptions[event_name].size()):
-		if _subscriptions[event_name][i].callback == callback:
-			index = i
-			break
+		if _subscriptions[event_name][i].is_anonymous:
+			if _subscriptions[event_name][i].callback == callback:
+				index = i
+				break
+		else:
+			if _subscriptions[event_name][i].callback_method == callback.get_method():
+				index = i
+				break
 	
 	if index != -1:
 		_subscriptions[event_name].remove_at(index)


### PR DESCRIPTION
WeakSubscription保存回调函数时，非匿名函数仅保存方法名，而未设置callback属性，导致callback属性为null，增加了判断is_anonymous，并根据其选择判断callback还是callback_method
#22 