### PR TITLE
scene_manager问题修复

### DIFF
--- a/source/scene_system/scene_manager.gd
+++ b/source/scene_system/scene_manager.gd
@@ -23,12 +23,14 @@ enum TransitionEffect {
 	FADE,       ## 淡入淡出
 	SLIDE,      ## 滑动
 	DISSOLVE,   ## 溶解
-	CUSTOM,      ## 自定义
+	CUSTOM,     ## 自定义
 }
 
 # 属性
 ## 当前场景
-var _current_scene: Node = null
+var _current_scene: Node:
+	get: return get_tree().get_current_scene()
+	set(value): get_tree().set_current_scene.call_deferred(value)
 ## 转场层
 var _transition_layer: CanvasLayer
 ## 转场矩形
@@ -60,15 +62,14 @@ var _logger : CoreSystem.Logger:
 var _preloaded_scenes: Array[String] = []
 
 func _ready() -> void:
-	var root : Window = get_tree().root
+	var root: Window = get_tree().root
 	if not root:
 		return
 	# 连接资源加载完成信号
 	if not _resource_manager.resource_loaded.is_connected(_on_resource_loaded):
 		_resource_manager.resource_loaded.connect(_on_resource_loaded)
+	# 初始化默认转场遮罩
 	_setup_transition_layer()
-	# 初始化当前场景
-	_current_scene = get_tree().current_scene
 	# 初始化默认转场效果
 	_setup_default_transitions()
 
@@ -86,11 +87,11 @@ func preload_scene(scene_path: String) -> void:
 ## [param duration] 转场持续时间
 ## [param callback] 切换完成回调
 func change_scene_async(
-		scene_path: String, 
+		scene_path: String,
 		scene_data: Dictionary = {},
 		push_to_stack: bool = false,
-		effect: TransitionEffect = TransitionEffect.NONE, 
-		duration: float = 0.5, 
+		effect: TransitionEffect = TransitionEffect.NONE,
+		duration: float = 0.5,
 		callback: Callable = Callable(),
 		custom_transition_name: StringName = ""
 		) -> void:
@@ -98,17 +99,17 @@ func change_scene_async(
 	if _is_switching:
 		_logger.warning("Scene switch already in progress, ignoring request to switch to: %s" % scene_path)
 		return
-		
+
 	_is_switching = true
 	scene_loading_started.emit(scene_path)
-	
+
 	# 检查场景栈中是否已存在该场景
 	var stack_index := -1
 	for i in _scene_stack.size():
 		if _scene_stack[i].scene_path == scene_path:
 			stack_index = i
 			break
-	
+
 	var new_scene : Node
 	if stack_index >= 0:
 		# 如果场景在栈中存在，重用该场景
@@ -119,7 +120,6 @@ func change_scene_async(
 			new_scene.init_state(scene_data)
 		# 从栈中移除该场景（因为它将成为当前场景）
 		_scene_stack.remove_at(stack_index)
-		new_scene.show()
 		new_scene.move_to_front()
 	else:
 		# 加载新场景
@@ -127,15 +127,15 @@ func change_scene_async(
 		if not new_scene:
 			var scene_resource : PackedScene = _resource_manager.get_cached_resource(scene_path)
 			new_scene = scene_resource.instantiate()
-		
+
 		if not new_scene:
 			_logger.error("Failed to load scene: %s" % scene_path)
 			_is_switching = false
 			return
-		
+
 		if new_scene.has_method("init_state"):
 			new_scene.init_state(scene_data)
-	
+
 	await _do_scene_switch(new_scene, effect, duration, callback, custom_transition_name, push_to_stack)
 	await get_tree().process_frame
 	_is_switching = false
@@ -144,30 +144,37 @@ func change_scene_async(
 ## [param effect] 转场效果
 ## [param duration] 持续时间
 ## [param callback] 回调
-func pop_scene_async(effect: TransitionEffect = TransitionEffect.NONE, 
-					duration: float = 0.5, 
+func pop_scene_async(effect: TransitionEffect = TransitionEffect.NONE,
+					duration: float = 0.5,
 					callback: Callable = Callable(),
 					custom_transition_name: StringName = ""
 					) -> void:
+	# 防止同时切换多个场景
+	if _is_switching:
+		_logger.warning("Scene switch already in progress.")
+		return
+
 	if _scene_stack.is_empty():
 		return
-		
+
+	_is_switching = true
 	var prev_scene_data = _scene_stack.pop_back()
 	var prev_scene = prev_scene_data.scene
-	
+
 	if prev_scene.has_method("restore_state"):
 		prev_scene.restore_state(prev_scene_data.data)
-	prev_scene.show()
+
 	await _do_scene_switch(prev_scene, effect, duration, callback, custom_transition_name)
-	
+	_is_switching = false
+
 ## 子场景管理
 ## [param parent_node] 父节点
 ## [param scene_path] 场景路径
 ## [param scene_data] 场景数据
 ## [return] 子场景
 func add_sub_scene(
-		parent_node: Node, 
-		scene_path: String, 
+		parent_node: Node,
+		scene_path: String,
 		scene_data: Dictionary = {}) -> Node:
 	var scene_resource = _resource_manager.load_resource(scene_path)
 	var sub_scene = scene_resource.instantiate()
@@ -235,14 +242,14 @@ func _setup_transition_layer() -> void:
 	_transition_layer = CanvasLayer.new()
 	_transition_layer.layer = 128  # 确保在最上层
 	add_child(_transition_layer)
-	
+
 	_transition_rect = ColorRect.new()
 	_transition_rect.color = Color.BLACK
 	_transition_rect.visible = false
 	_transition_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE  # 忽略鼠标输入
 	_transition_layer.add_child(_transition_rect)
-	
-	var root : Window = get_tree().root
+
+	var root: Window = get_tree().root
 	if not root.size_changed.is_connected(_on_viewport_size_changed):
 		root.size_changed.connect(_on_viewport_size_changed)
 	_on_viewport_size_changed()
@@ -267,24 +274,24 @@ func _setup_default_transitions() -> void:
 ## [param callback] 回调
 ## [param save_current] 是否保存当前场景
 func _do_scene_switch(
-		new_scene: Node, 
-		effect: TransitionEffect, 
-		duration: float, 
-		callback: Callable, 
+		new_scene: Node,
+		effect: TransitionEffect,
+		duration: float,
+		callback: Callable,
 		custom_transition_name: StringName = "",
 		save_current: bool = false
 		) -> void:
-	var old_scene : Node = _current_scene
+	var old_scene: Node = _current_scene
 
 	# 开始转场效果
 	if effect != TransitionEffect.NONE:
 		await _start_transition(effect, duration, custom_transition_name)
-		
+
 	# 添加新场景
 	if not new_scene.get_parent():
 		get_tree().root.call_deferred("add_child", new_scene)
 	_current_scene = new_scene
-	
+
 	if save_current and old_scene:
 		# 保存当前场景到栈
 		_scene_stack.push_back({
@@ -292,27 +299,27 @@ func _do_scene_switch(
 			"scene_path": old_scene.scene_file_path,
 			"data": old_scene.save_state() if old_scene.has_method("save_state") else {},
 		})
-		old_scene.hide()
+		old_scene.get_parent().remove_child(old_scene)
 	else:
 		# 如果不需要保存状态，则直接销毁当前场景
 		if old_scene:
-			old_scene.get_parent().call_deferred("remove_child", old_scene)
+			old_scene.get_parent().remove_child(old_scene)
 			old_scene.queue_free()
-	
+
 	# 结束转场效果
 	if effect != TransitionEffect.NONE:
 		await _end_transition(effect, duration, custom_transition_name)
 		_cleanup_transition(effect, custom_transition_name)
-	
+
 	## 场景切换后强制更新新场景的相机
 	call_deferred("_update_new_scene_camera",new_scene)
-	
+
 	scene_changed.emit(old_scene, new_scene)
 
 	# 回调
 	if callback.is_valid():
-		callback.call()        
-	
+		callback.call()
+
 	scene_loading_finished.emit()
 
 ## 资源加载完成回调
@@ -325,7 +332,7 @@ func _update_new_scene_camera(new_scene:Node):
 	if new_scene == null:
 		push_error("new_scene is null!")
 		return
-	
+
 	var new_scene_viewport = new_scene.get_viewport()
 	if new_scene_viewport != null:
 		if new_scene_viewport.get_camera_2d() != null:

--- a/source/scene_system/scene_manager.gd
+++ b/source/scene_system/scene_manager.gd
@@ -73,11 +73,21 @@ func _ready() -> void:
 	# 初始化默认转场效果
 	_setup_default_transitions()
 
+func _exit_tree() -> void:
+	clear_scene_stack()
+
 ## 预加载场景
 ## @param scene_path 场景路径
 func preload_scene(scene_path: String) -> void:
 	_preloaded_scenes.append(scene_path)
 	_resource_manager.load_resource(scene_path, _resource_manager.LOAD_MODE.LAZY)
+
+## 确保所有栈中的孤儿节点均被释放
+func clear_scene_stack() -> void:
+	for stack in _scene_stack:
+		var scene: Node = stack.get("scene") as Node
+		scene.queue_free()
+	_scene_stack.clear()
 
 ## 异步切换场景
 ## [param scene_path] 场景路径

--- a/source/scene_system/transitions/fade_transition.gd
+++ b/source/scene_system/transitions/fade_transition.gd
@@ -7,6 +7,7 @@ class_name FadeTransition
 ## 执行开始转场
 ## @param duration 转场持续时间
 func _do_start(duration: float) -> void:
+	_transition_rect.color.a = 0.0
 	var tween = _transition_rect.create_tween()
 	tween.tween_property(_transition_rect, "color:a", 1.0, duration)
 	await tween.finished


### PR DESCRIPTION
# 📝 Pull Request

## 🔍 变更类型

<!-- 在相关选项前打 [x] -->

- [ ] 📚 新增文档
- [ ] 🔧 文档更新
- [x] 🐛 错误修复
- [ ] 🌐 翻译改进
- [x] 🎨 格式优化
- [ ] 📊 内容重组
- [ ] 其他：

## 📋 变更描述

<!-- 详细描述这次PR的变更内容 -->

### 变更文件

<!-- 列出所有变更的文件 -->

1. source/scene_system/scene_manager.gd
2. source/scene_system/transitions/fade_transition.gd
3. 

### 主要改动
统一了_current_scene属性的使用，修复了pop_scene_async未应用_is_switching判断条件的问题，修复了push_to_stack后上个场景仍继续运行导致场景重复堆叠的问题，修复了fade_transition的实际运行效果。
<!-- 描述主要的改动点 -->

## 💡 变更原因
统一current_scene属性是为了避免用户端对管理器与官方场景转换函数的混用引发的场景堆叠问题，
修复pop_scene_async是因为该函数也调用了do_switching函数，
修复了仅仅是隐藏节点则该场景会继续在后台运行，导致有可能反复调用转换场景函数导致同一场景重复堆叠，
修复了fade_transition错误的视觉效果，应在do_start前将遮罩颜色重制。
另外在删除上个场景时不应延迟调用remove_child，否则在转场不为none的情况下会触发节点已被释放以至于无法运行该函数的bug，也给予了修正。
<!-- 说明为什么需要这些变更 -->

## 📸 变更效果

<!-- 如果适用，提供变更前后的对比截图 -->

**变更前：**

**变更后：**

## ✅ 检查清单

<!-- 在完成的项目前打 [x] -->

- [ ] 我已阅读并遵循了[贡献指南](../CONTRIBUTING.md)
- [ ] 所有文档格式符合规范
- [ ] 更新了相关的目录和索引
- [ ] 检查了文内链接的有效性
- [ ] 更新了相关的翻译版本（如果有）
- [ ] 文档经过了本地预览测试

## 👥 相关人员

<!-- @提及需要关注此PR的人员 -->

## 📝 补充说明

<!-- 其他需要补充的信息 -->

---
⚠️ 注意：

- PR标题应简洁明了地描述变更内容
- 大型文档变更建议先在Issue中讨论
- 如果修复了某个Issue，请在描述中引用它：`Fixes #Issue编号`
